### PR TITLE
fix: update playground startup command in documentation

### DIFF
--- a/src/how-read.md
+++ b/src/how-read.md
@@ -82,7 +82,7 @@ Since Vapor Mode is currently in R&D, the source code changes frequently. \
 It would be quite inconvenient if it changes while we're reading it, so let's find a way to use the vuejs/core-vapor we just checked out locally to confirm things.
 
 In vuejs/core-vapor, there is a directory called `/playground`. \
-You can start this playground by running `pnpm dev-vapor` in `vuejs/core-vapor`. \
+You can start this playground by running `pnpm dev` in `vuejs/core-vapor`. \
 There are some components placed in `/playground/src`. When you access the started playground, you'll find that `/playground/src/App.vue` is running in your browser.
 
 In this playground, `/playground/src` corresponds to routing. For example, if you access `http://localhost:5173/components.vue`, `/playground/src/components.vue` will be executed. \

--- a/src/ja/how-read.md
+++ b/src/ja/how-read.md
@@ -82,7 +82,7 @@ Vapor Mode は現在 R&D が進行中のためソースコードは頻繁に変�
 読んでる間にも変わってしまうとかなり不都合なので，どうにかして先ほどチェックアウトした手元の vuejs/core-vapor を使って確認できるようにしましょう．
 
 vuejs/core-vapor には `/playground` というディレクトリがあります．\
-`vuejs/core-vapor` で `pnpm dev-vapor` を実行することでこの playground を起動することができます．\
+`vuejs/core-vapor` で `pnpm dev` を実行することでこの playground を起動することができます．\
 そして `/playground/src` にいくつかのコンポーネントが置かれています．起動した playground にアクセスすると，`/playground/src/App.vue` がブラウザで実行されることがわかります．
 
 この playground では `/playground/src` がルーティングに対応していて，例えば， `http://localhost:5173/components.vue` にアクセスすると `/playground/src/components.vue` が実行されます．\


### PR DESCRIPTION
## Description

Updated the playground startup command from `pnpm dev-vapor` to `pnpm dev`.

https://github.com/vuejs/vue-vapor/blob/30583b9ee1c696d3cb836f0bfd969793e57e849d/playground/package.json#L1-L21